### PR TITLE
comment out mask rtorrent.rc setting by default

### DIFF
--- a/root/defaults/rtorrent.rc
+++ b/root/defaults/rtorrent.rc
@@ -26,4 +26,4 @@ peer_exchange = yes
 # network.http.ssl_verify_peer.set=0
 # scgi_port = 0.0.0.0:5000
 encoding_list = UTF-8
-system.umask.set = 022
+# system.umask.set = 022


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io


+ comment out system mask setting in rtorrent.rc file